### PR TITLE
Suggestions for manpage update

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,4 @@
 license_file = License
 [build_manpages]
 manpages =
-    # solution 1: --split up the commandline_arguments parser
     man/git-fleximod.1:function:commandline_arguments:pyfile=src/git-fleximod
-    # solution 2 -- make parser global
-    #man/git-fleximod.2:pyfile=src/git-fleximod:object=parser

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 license_file = License
 [build_manpages]
 manpages =
-    # solution 1: --split up the commandline_arguments parser --better
-    #man/git-fleximod.1:function:commandline_arguments:pyfile=src/git-fleximod
+    # solution 1: --split up the commandline_arguments parser
+    man/git-fleximod.1:function:commandline_arguments:pyfile=src/git-fleximod
     # solution 2 -- make parser global
-    man/git-fleximod.2:pyfile=src/git-fleximod:object=parser
+    #man/git-fleximod.2:pyfile=src/git-fleximod:object=parser

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 license_file = License
 [build_manpages]
 manpages =
-    # solution 1: --split up the commandline_arguments parser
+    # solution 1: --split up the commandline_arguments parser --better
     #man/git-fleximod.1:function:commandline_arguments:pyfile=src/git-fleximod
     # solution 2 -- make parser global
     man/git-fleximod.2:pyfile=src/git-fleximod:object=parser

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,7 @@
 license_file = License
 [build_manpages]
 manpages =
-    man/git-fleximod.1:object=parser:pyfile=bin/git-fleximod
+    # solution 1: --split up the commandline_arguments parser
+    #man/git-fleximod.1:function:commandline_arguments:pyfile=src/git-fleximod
+    # solution 2 -- make parser global
+    man/git-fleximod.2:pyfile=src/git-fleximod:object=parser

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [metadata]
 license_file = License
+[build_manpages]
+manpages =
+    man/git-fleximod.1:object=parser:pyfile=bin/git-fleximod

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 license_file = License
 [build_manpages]
 manpages =
-    # solution 1: --split up the commandline_arguments parser
-    man/git-fleximod.1:function:commandline_arguments:pyfile=src/git-fleximod
+    # solution 1: -- use parser function
+    man/git-fleximod.1:function=get_parser:pyfile=src/git-fleximod
     # solution 2 -- make parser global
     #man/git-fleximod.2:pyfile=src/git-fleximod:object=parser

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,7 @@
 license_file = License
 [build_manpages]
 manpages =
+    # solution 1: --split up the commandline_arguments parser
     man/git-fleximod.1:function:commandline_arguments:pyfile=src/git-fleximod
+    # solution 2 -- make parser global
+    #man/git-fleximod.2:pyfile=src/git-fleximod:object=parser

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import setuptools
 import os
 from setuptools import setup, find_packages
 from distutils.util import convert_path
+from build_manpages import build_manpages, get_build_py_cmd, get_install_cmd
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -31,5 +32,12 @@ setuptools.setup(
     ],                                      # Information to filter the project on PyPi website
     python_requires='>=3.6',                # Minimum version requirement of the package
 #    py_modules=['git-fleximod'],             # Name of the python package
-    install_requires=["GitPython"]                     # Install other dependencies if any
+    install_requires=["GitPython"],                     # Install other dependencies if any
+    cmdclass={
+      'build_manpages': build_manpages,
+      # Re-define build_py and install commands so the manual pages
+      # are automatically re-generated and installed
+      'build_py': get_build_py_cmd(),
+      'install': get_install_cmd(),
+  }
 )

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@ import setuptools
 import os
 from setuptools import setup, find_packages
 from distutils.util import convert_path
+from setuptools.command.build_py import build_py
+from setuptools.command.install import install
 from build_manpages import build_manpages, get_build_py_cmd, get_install_cmd
 
 with open("README.md", "r") as fh:
@@ -14,7 +16,8 @@ with open(ver_path) as ver_file:
 
     
 setuptools.setup(
-    scripts=["src/git-fleximod"],                     # This is the name of the package
+    name="git-fleximod",                      # package name
+    #scripts=["src/git-fleximod"],                     # This is the name of the package
     version=main_ns['__version__'],                        # The initial release version
     author="Jim Edwards",                     # Full name of the author
     maintainer="jedwards4b",
@@ -38,6 +41,6 @@ setuptools.setup(
       # Re-define build_py and install commands so the manual pages
       # are automatically re-generated and installed
       'build_py': get_build_py_cmd(),
-      'install': get_install_cmd(),
+      'install': get_install_cmd(install),
   }
 )

--- a/src/git-fleximod
+++ b/src/git-fleximod
@@ -236,11 +236,28 @@ def submodule_checkout(root, name, path, url=None, tag=None):
             tmpurl = url
             url = url.replace("git@github.com:", "https://github.com")            
             git.git_operation("clone", url, path)
-            smgit = GitInterface(path, logger)
+            smgit = GitInterface(repodir, logger)
             if not tag:
                 tag = smgit.git_operation("describe", "--tags", "--always").rstrip()
             smgit.git_operation("checkout",tag)
             # Now need to move the .git dir to the submodule location
+            rootdotgit = os.path.join(root,".git")
+            if os.path.isfile(rootdotgit):
+                with open(rootdotgit) as f:
+                    line = f.readline()
+                    if line.startswith("gitdir: "):
+                        rootdotgit = line[8:].rstrip()
+            
+            newpath = os.path.abspath(os.path.join(root,rootdotgit,"modules",path))
+            print(f"root is {root} rootdotgit is {rootdotgit} newpath is {newpath}")
+            if not os.path.isdir(os.path.join(newpath,os.pardir)):
+                os.makedirs(os.path.abspath(os.path.join(newpath,os.pardir)))
+
+            shutil.move(os.path.join(repodir,".git"), newpath) 
+            with open(os.path.join(repodir,".git"), "w") as f:
+                f.write("gitdir: "+newpath)
+            
+
             
             
     if not tmpurl:

--- a/src/git-fleximod
+++ b/src/git-fleximod
@@ -24,8 +24,7 @@ def find_root_dir(filename=".git"):
         d = d.parent
     return None
     
-
-def commandline_arguments(args=None):
+def get_parser():
     description = """
     %(prog)s manages checking out groups of gitsubmodules with addtional support for Earth System Models
     """
@@ -126,6 +125,11 @@ def commandline_arguments(args=None):
         help="DEVELOPER: output additional debugging "
         "information to the screen and log file.",
     )
+
+    return parser
+
+def commandline_arguments(args=None):
+    parser = get_parser()
 
     if args:
         options = parser.parse_args(args)

--- a/src/git-fleximod
+++ b/src/git-fleximod
@@ -60,6 +60,13 @@ def commandline_arguments(args=None):
         nargs="*",
         help="Component(s) listed in the gitmodules file which should be ignored.",
     )
+    parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        default=False,
+        help="Override cautions and update or checkout over locally modified repository."
+    )
 
     parser.add_argument(
         "-o",
@@ -152,6 +159,7 @@ def commandline_arguments(args=None):
         options.components,
         options.exclude,
         options.verbose,
+        options.force,
         action,
     )
 
@@ -281,6 +289,7 @@ def submodule_checkout(root, name, path, url=None, tag=None):
 
 def submodules_status(gitmodules, root_dir):
     testfails = 0
+    localmods = 0
     for name in gitmodules.sections():
         path = gitmodules.get(name, "path")
         tag = gitmodules.get(name, "fxtag")
@@ -321,11 +330,17 @@ def submodules_status(gitmodules, root_dir):
 
                 status = git.git_operation("status","--ignore-submodules")
                 if "nothing to commit" not in status:
+                    localmods = localmods+1
                     print('M'+textwrap.indent(status,'                      '))
     
-    return testfails
+    return testfails, localmods
 
-def submodules_update(gitmodules, root_dir):
+def submodules_update(gitmodules, root_dir, force):
+    _,localmods = submodules_status(gitmodules, root_dir)
+    print("")
+    if localmods and not force:
+        print(f"Repository has local mods, cowardly refusing to continue, fix issues or use --force to override")
+        return
     for name in gitmodules.sections():
         fxtag = gitmodules.get(name, "fxtag")
         path = gitmodules.get(name, "path")
@@ -358,15 +373,20 @@ def submodules_update(gitmodules, root_dir):
                     git.git_operation("fetch", newremote, "--tags")
                 atag = git.git_operation("describe", "--tags", "--always").rstrip()
                 if fxtag and fxtag != atag:
-                    print(f"Updating {name} to {fxtag}")
+                    print(f"{name:>20} updated to {fxtag}")
                     git.git_operation("checkout", fxtag)
                 elif not fxtag:
-                    print(f"No fxtag found for submodule {name}")
+                    print(f"No fxtag found for submodule {name:>20}")
                 else:
-                    print(f"submodule {name} up to date.")
+                    print(f"{name:>20} up to date.")
 
 
-def submodules_checkout(gitmodules, root_dir, requiredlist):
+def submodules_checkout(gitmodules, root_dir, requiredlist, force):
+    _,localmods = submodules_status(gitmodules, root_dir)
+    print("")
+    if localmods and not force:
+        print(f"Repository has local mods, cowardly refusing to continue, fix issues or use --force to override")
+        return
     for name in gitmodules.sections():
         fxrequired = gitmodules.get(name, "fxrequired")
         fxsparse = gitmodules.get(name, "fxsparse")
@@ -393,7 +413,7 @@ def submodules_checkout(gitmodules, root_dir, requiredlist):
 
 def submodules_test(gitmodules, root_dir):
     # First check that fxtags are present and in sync with submodule hashes
-    testfails = submodules_status(gitmodules, root_dir)
+    testfails,localmods = submodules_status(gitmodules, root_dir)
     # Then make sure that urls are consistant with fxurls (not forks and not ssh)
     # and that sparse checkout files exist
     for name in gitmodules.sections():
@@ -407,7 +427,7 @@ def submodules_test(gitmodules, root_dir):
         if fxsparse and not os.path.isfile(os.path.join(root_dir, path, fxsparse)):
             print(f"sparse submodule {name} sparse checkout file {fxsparse} not found")
             testfails += 1
-    return testfails
+    return testfails+localmods
 
 
             
@@ -419,6 +439,7 @@ def _main_func():
         includelist,
         excludelist,
         verbose,
+        force,
         action,
     ) = commandline_arguments()
     # Get a logger for the package
@@ -445,9 +466,9 @@ def _main_func():
     )
     retval = 0
     if action == "update":
-        submodules_update(gitmodules, root_dir)
+        submodules_update(gitmodules, root_dir, force)
     elif action == "checkout":
-        submodules_checkout(gitmodules, root_dir, fxrequired)
+        submodules_checkout(gitmodules, root_dir, fxrequired, force)
     elif action == "status":
         submodules_status(gitmodules, root_dir)
     elif action == "test":

--- a/src/git-fleximod
+++ b/src/git-fleximod
@@ -5,6 +5,7 @@ import shutil
 import logging
 import argparse
 import textwrap
+from pathlib import Path
 from fleximod import utils
 from fleximod.gitinterface import GitInterface
 from fleximod.gitmodules import GitModules
@@ -12,6 +13,17 @@ from fleximod.version import __version__
 from configparser import NoOptionError
 # logger variable is global
 logger = None
+
+def find_root_dir(filename=".git"):
+    d = Path.cwd()
+    root = Path(d.root)
+    while d != root:
+        attempt = d / filename
+        if attempt.is_dir():
+            return attempt
+        d = d.parent
+    return None
+    
 
 def commandline_arguments(args=None):
     description = """
@@ -42,8 +54,8 @@ def commandline_arguments(args=None):
     parser.add_argument(
         "-C",
         "--path",
-        default=os.getcwd(),
-        help="Toplevel repository directory.  Defaults to current directory.",
+        default=find_root_dir(),
+        help="Toplevel repository directory.  Defaults to top git directory relative to current.",
     )
 
     parser.add_argument(
@@ -430,6 +442,7 @@ def submodules_test(gitmodules, root_dir):
     return testfails+localmods
 
 
+
             
 def _main_func():
     (
@@ -455,6 +468,7 @@ def _main_func():
             utils.fatal_error(
                 "No {} found in {} or any of it's parents".format(file_name, root_dir)
             )
+
         root_dir = os.path.dirname(file_path)
     logger.info(f"root_dir is {root_dir}")
     gitmodules = GitModules(

--- a/src/git-fleximod
+++ b/src/git-fleximod
@@ -125,6 +125,10 @@ def commandline_arguments(args=None):
     handlers=[logging.StreamHandler()]
 
     if options.debug:
+        try:
+            open("fleximod.log","w")
+        except PermissionError:
+            sys.exit("ABORT: Could not write file fleximod.log")
         level = logging.DEBUG
         handlers.append(logging.FileHandler("fleximod.log"))
     elif options.verbose:

--- a/src/git-fleximod
+++ b/src/git-fleximod
@@ -122,9 +122,11 @@ def commandline_arguments(args=None):
     action = options.action
     if not action:
         action = "checkout"
+    handlers=[logging.StreamHandler()]
 
     if options.debug:
         level = logging.DEBUG
+        handlers.append(logging.FileHandler("fleximod.log"))
     elif options.verbose:
         level = logging.INFO
     else:
@@ -133,8 +135,9 @@ def commandline_arguments(args=None):
     logging.basicConfig(
         level=level,
         format="%(name)s - %(levelname)s - %(message)s",
-        handlers=[logging.FileHandler("fleximod.log"), logging.StreamHandler()],
+        handlers=handlers
     )
+    
     if hasattr(options, 'version'):
         exit()
     
@@ -228,7 +231,11 @@ def submodule_checkout(root, name, path, url=None, tag=None):
         if url.startswith("git@"):
             tmpurl = url
             url = url.replace("git@github.com:", "https://github.com")            
-            git.git_operation("clone", "-b", tag, url, path)
+            git.git_operation("clone", url, path)
+            smgit = GitInterface(path, logger)
+            if not tag:
+                tag = smgit.git_operation("describe", "--tags", "--always").rstrip()
+            smgit.git_operation("checkout",tag)
             # Now need to move the .git dir to the submodule location
             
             
@@ -272,28 +279,28 @@ def submodules_status(gitmodules, root_dir):
                     atag = (htag.split()[1])[10:]
                     break
             if tag == atag:
-                print(f"Submodule {name} not checked out, aligned at tag {tag}")
+                print(f"e {name:>20} not checked out, aligned at tag {tag}")
             else:
-                print(f"Submodule {name} not checked out, out of sync at tag {atag}, expected tag is {tag}")
+                print(f"e {name:>20} not checked out, out of sync at tag {atag}, expected tag is {tag}")
                 testfails += 1
         else:
             with utils.pushd(newpath):
                 git = GitInterface(newpath, logger)
                 atag = git.git_operation("describe", "--tags", "--always").rstrip()
                 if tag and atag != tag:
-                    print(f"Submodule {name} {atag} is out of sync with .gitmodules {tag}")
+                    print(f"s {name:>20} {atag} is out of sync with .gitmodules {tag}")
                     testfails += 1
                 elif tag:
-                    print(f"Submodule {name} at tag {tag}")
+                    print(f"  {name:>20} at tag {tag}")
                 else:
                     print(
-                        f"Submodule {name} has no tag defined in .gitmodules, module at {atag}"
+                        f"e {name:>20} has no tag defined in .gitmodules, module at {atag}"
                     )
                     testfails += 1
 
                 status = git.git_operation("status","--ignore-submodules")
                 if "nothing to commit" not in status:
-                    print(textwrap.indent(status,'    '))
+                    print('M'+textwrap.indent(status,'                      '))
     
     return testfails
 


### PR DESCRIPTION
The man page building with [argparse-manpage](https://github.com/praiskup/argparse-manpage/tree/main) was not working due to a few issues. Most importantly the `argparse-manpage` creates the man page from `ArgumentParser` object or a `parser` function. The issue was that here you were not pointing to the correct `pyfile` and  `ArgumentParser` object. 


Here I updated the setup.cfg file to show two different possible solutions that required minimal work:

1. Using a parser function, such as `commandline_arguments`. 
```
[build_manpages]
manpages =
    # solution 1: -- Using the parser function, requires slight modifications to split up the commandline_arguments parser
    man/git-fleximod.1:function:commandline_arguments:pyfile=src/git-fleximod
```
This solution use a parser function but we could not directly use `commandline_arguments` as it have some condition checking and failed as it was due to missing arguments.  I splitted up the `commandline_arguments`  function to two functions (one that return the  `ArgumentParser` object and one that does the rest of the processing and option checking. 

2. Making the `ArgumentParser` object global object in `git-fleximod` and using it instead: 

```
manpages =
        man/git-fleximod.2:pyfile=src/git-fleximod:object=parser
 ``` 
 
 I updated this PR to use solution 1 as the better option but I just wanted you to be aware of solution 2. 