### PR TITLE
update should checkout if needed

### DIFF
--- a/tests/test_sparse_update.py
+++ b/tests/test_sparse_update.py
@@ -20,7 +20,7 @@ def test_sparse_checkout(git_fleximod, test_repo_base):
 """
     (test_repo_base / "modules" / ".sparse_file_list").write_text(sparse_content)
 
-    result = git_fleximod("checkout")
+    result = git_fleximod("update")
     
     # Assertions
     assert result.returncode == 0
@@ -31,8 +31,3 @@ def test_sparse_checkout(git_fleximod, test_repo_base):
 
     assert "test_sparse_submodule at tag MPIserial_2.5.0" in status.stdout
 
-    result = git_fleximod("update")
-    assert result.returncode == 0
-
-    status = git_fleximod("status test_sparse_submodule")
-    assert "test_sparse_submodule at tag MPIserial_2.5.0" in status.stdout

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -15,18 +15,13 @@ def test_basic_checkout(git_fleximod, test_repo):
     (test_repo / ".gitmodules").write_text(gitmodules_content)
     
     # Run the command
-    result = git_fleximod("checkout")
+    result = git_fleximod("update")
 
     # Assertions
     assert result.returncode == 0
     assert Path(test_repo / "modules/test").exists()   # Did the submodule directory get created?
 
     status = git_fleximod("status")
-
-    assert "test_submodule d82ce7c is out of sync with .gitmodules MPIserial_2.4.0" in status.stdout
-
-    result = git_fleximod("update")
-    assert result.returncode == 0
 
     status = git_fleximod("status")
     assert "test_submodule at tag MPIserial_2.4.0" in status.stdout


### PR DESCRIPTION
The update command should checkout anything that hasn't already been checked out when an update is requested.  I think that this eliminates the need for a separate checkout command.  But not removing it yet.